### PR TITLE
Fix to avoid "cout not in std" error

### DIFF
--- a/version_config.h.in
+++ b/version_config.h.in
@@ -1,6 +1,7 @@
 #ifndef VERSION_CONFIG_H
 #define VERSION_CONFIG_H
 
+#include <iostream>
 #include <stdio.h>
 #include <boost/format.hpp>
 


### PR DESCRIPTION
I tried to build version 0.3.03 of pout2mzid on Ubuntu 16.04 with:
cd builddir
cmake -B pout2mzid_repo/CMakeLists.txt -B
make

But that errored with "cout not in std" in version_config.h.

This line made so it could be built with distro-provided cmake (3.5.1), compilers (g++5), xerces (3.1.3).
